### PR TITLE
Show an error on mal-formed JSON file

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,9 +1,10 @@
 {
-    "@metadata": {
+	"@metadata": {
 	"authors": [
-	    "Mark A. Hershberger"
+		"Mark A. Hershberger"
 	]
-    },
-    "nsmgr-extensionname": "NamespaceManager",
-    "nsmgr-desc": "Provide a special page to handle namespaces."
+	},
+	"nsmgr-extensionname": "NamespaceManager",
+	"nsmgr-desc": "Provide a special page to handle namespaces.",
+	"nsmgr-json-exception": "Got '$1' while parsing $2"
 }

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -23,8 +23,9 @@
 namespace MediaWiki\Extension\NamespaceManager;
 
 use DatabaseUpdater;
-use MWException;
 use FormOptions;
+use JsonException;
+use MWException;
 use stdClass;
 use Title;
 
@@ -109,7 +110,15 @@ class Hooks {
 		$nsConfig = false;
 		if ( file_exists( $nsConf ) ) {
 			if ( is_readable( $nsConf ) ) {
-				$nsConfig = json_decode( file_get_contents( $nsConf ) );
+				try {
+					$nsConfig = json_decode(
+						file_get_contents( $nsConf ), false, 512, JSON_THROW_ON_ERROR
+					);
+				} catch ( JsonException $e ) {
+					// At this point MW error handling is not set up.
+					echo wfMessage( 'nsmgr-json-exception' )->params( $e->getMessage(), $nsConf )->plain();
+					exit;
+				}
 			}
 		} else {
 			$nsConfig = new stdClass;


### PR DESCRIPTION
We aren't throwing an exception here because exception handling is not set up this early.

Fixes #3