### PR TITLE
Add protected ns permission to $wgGrantPermissions[ ‘editprotected' ]

### DIFF
--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -166,6 +166,7 @@ class Hooks {
 		global $wgNamespaceHideFromRC;
 		global $wgNamespaceProtection;
 		global $wgNonincludableNamespaces;
+		global $wgGrantPermissions;
 
 		$const = $conf->id;
 		$talkConst = $conf->id + 1;
@@ -180,6 +181,7 @@ class Hooks {
 			$wgGroupPermissions['*'][$permission] = false;
 			$wgGroupPermissions[ $group ][$permission] = true;
 			$wgGroupPermissions[ $adminGroup ][$permission] = true;
+			$wgGrantPermissions[ 'editprotected' ][$permission] = true;
 			$wgNamespaceProtection[ $const ] = $permission;
 			$wgNamespaceProtection[ $talkConst ] = $permission;
 			$wgNamespaceHideFromRC[] = $const;


### PR DESCRIPTION
This allows botpassword accounts to work with protected namespaces.

fixes #2